### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,8 @@
 
 
 name: Java Maven Build & Publish Artifact
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/akkki98/javaactions/security/code-scanning/2](https://github.com/akkki98/javaactions/security/code-scanning/2)

To fix this problem, you should explicitly specify a `permissions` block in your workflow. The ideal location is at the root level of the workflow file so it applies to all jobs by default. If you know that only minimal permissions are needed (as in typical read-only artifact build/publish workflows), you may use `contents: read`. If in the future, a job needs specific write permissions (e.g., to create releases), you can grant those at the individual job level.  

**Specific steps:**  
- At the root of `.github/workflows/maven.yml`, add a `permissions` block right below the `name` and above the `on` block.  
- Set `contents: read` as the minimal required starting point.  
- Do not make any other changes to workflow steps.

No new imports, methods, or variable definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
